### PR TITLE
fixed percl command that cannot be sent in call queue

### DIFF
--- a/inboundCallQueue.js
+++ b/inboundCallQueue.js
@@ -56,8 +56,8 @@ app.post('/callDequeue', (req, res) => {
     const percl = freeclimb.percl.build(dequeue)
     res.status(200).json(percl)
   } else {
-    const redirect = freeclimb.percl.redirect(`${host}/inboundCallWait`)
-    const percl = freeclimb.percl.build(redirect)
+    const say = freeclimb.percl.say('No key pressed. Staying in queue.')
+    const percl = freeclimb.percl.build(say)
     res.status(200).json(percl)
   }
 })


### PR DESCRIPTION
Redirect PerCL commands aren't allowed in call queues anymore. Removed it. 